### PR TITLE
Introduce spi.AuthenticatedUser as subjects of access control

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
+++ b/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
@@ -61,6 +61,6 @@ public class AuthRequestFilter
     private AuthenticatedUser getAuthenticatedUser(final Authenticator.Result result)
     {
         final Config userInfo = result.getUserInfo().or(cf.create());
-        return result.getAuthenticatedUser().or(AuthenticatedUser.of(result.getSiteId(), userInfo));
+        return result.getAuthenticatedUser().or(AuthenticatedUser.of(result.getSiteId(), userInfo, ImmutableMap.of()));
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
+++ b/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
@@ -45,10 +45,11 @@ public class AuthRequestFilter
 
         Authenticator.Result result = auth.authenticate(requestContext);
         if (result.isAccepted()) {
-            requestContext.setProperty("siteId", result.getSiteId());
-            requestContext.setProperty("userInfo", result.getUserInfo().or(cf.create()));
+            requestContext.setProperty("siteId", result.getSiteId()); // TODO will be merged into authenticatedUser
+            requestContext.setProperty("userInfo", result.getUserInfo().or(cf.create())); //TODO will be merged into authenticatedUser
             requestContext.setProperty("secrets", result.getSecrets().or(Suppliers.ofInstance(ImmutableMap.of())));
             requestContext.setProperty("admin", result.isAdmin());
+            requestContext.setProperty("authenticatedUser", result.getAuthenticatedUser().orNull());
         }
         else {
             requestContext.abortWith(errorResultHandler.toResponse(result.getErrorMessage()));

--- a/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
+++ b/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
@@ -3,7 +3,6 @@ package io.digdag.server;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.spi.AuthenticatedUser;
 
@@ -60,7 +59,12 @@ public class AuthRequestFilter
 
     private AuthenticatedUser getAuthenticatedUser(final Authenticator.Result result)
     {
-        final Config userInfo = result.getUserInfo().or(cf.create());
-        return result.getAuthenticatedUser().or(AuthenticatedUser.of(result.getSiteId(), userInfo, ImmutableMap.of()));
+        return result.getAuthenticatedUser()
+                .or(AuthenticatedUser.builder()
+                        .siteId(result.getSiteId())
+                        .userInfo(result.getUserInfo().or(cf.create()))
+                        .userContext(cf.create())
+                        .build()
+                );
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/Authenticator.java
+++ b/digdag-server/src/main/java/io/digdag/server/Authenticator.java
@@ -30,12 +30,12 @@ public interface Authenticator
 
         static Result accept(int siteId, Config userInfo)
         {
-            return accept(siteId, Optional.fromNullable(userInfo), Optional.absent());
+            return accept(siteId, Optional.fromNullable(userInfo), Optional.of(AuthenticatedUser.of(siteId, userInfo)));
         }
 
         static Result accept(int siteId, Config userInfo, AuthenticatedUser user)
         {
-            return accept(siteId, Optional.fromNullable(userInfo), Optional.fromNullable(user));
+            return accept(siteId, Optional.fromNullable(userInfo), Optional.of(user));
         }
 
         static Result accept(int siteId, Optional<Config> userInfo, Optional<AuthenticatedUser> user)

--- a/digdag-server/src/main/java/io/digdag/server/Authenticator.java
+++ b/digdag-server/src/main/java/io/digdag/server/Authenticator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import io.digdag.client.config.Config;
+import io.digdag.spi.AuthenticatedUser;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
@@ -24,19 +25,25 @@ public interface Authenticator
     {
         static Result accept(int siteId)
         {
-            return accept(siteId, Optional.absent());
+            return accept(siteId, Optional.absent(), Optional.absent());
         }
 
         static Result accept(int siteId, Config userInfo)
         {
-            return accept(siteId, Optional.fromNullable(userInfo));
+            return accept(siteId, Optional.fromNullable(userInfo), Optional.absent());
         }
 
-        static Result accept(int siteId, Optional<Config> userInfo)
+        static Result accept(int siteId, Config userInfo, AuthenticatedUser user)
+        {
+            return accept(siteId, Optional.fromNullable(userInfo), Optional.fromNullable(user));
+        }
+
+        static Result accept(int siteId, Optional<Config> userInfo, Optional<AuthenticatedUser> user)
         {
             return ImmutableResult.builder()
                     .siteId(siteId)
                     .userInfo(userInfo)
+                    .authenticatedUser(user)
                     .build();
         }
 
@@ -46,6 +53,7 @@ public interface Authenticator
                     .siteId(0)
                     .errorMessage(message)
                     .userInfo(Optional.absent())
+                    .authenticatedUser(Optional.absent())
                     .build();
         }
 
@@ -68,6 +76,8 @@ public interface Authenticator
 
         Optional<Supplier<Map<String, String>>> getSecrets();
 
+        Optional<AuthenticatedUser> getAuthenticatedUser();
+
         static Builder builder() {
             return ImmutableResult.builder();
         }
@@ -78,6 +88,7 @@ public interface Authenticator
             Builder secrets(Supplier<Map<String, String>> secrets);
             Builder isAdmin(boolean admin);
             Builder errorMessage(String errorMessage);
+            Builder authenticatedUser(AuthenticatedUser user);
             Result build();
         }
     }

--- a/digdag-server/src/main/java/io/digdag/server/Authenticator.java
+++ b/digdag-server/src/main/java/io/digdag/server/Authenticator.java
@@ -30,7 +30,7 @@ public interface Authenticator
 
         static Result accept(int siteId, Config userInfo)
         {
-            return accept(siteId, Optional.fromNullable(userInfo), Optional.of(AuthenticatedUser.of(siteId, userInfo)));
+            return accept(siteId, Optional.fromNullable(userInfo), Optional.absent());
         }
 
         static Result accept(int siteId, Config userInfo, AuthenticatedUser user)

--- a/digdag-server/src/main/java/io/digdag/server/JwtAuthenticator.java
+++ b/digdag-server/src/main/java/io/digdag/server/JwtAuthenticator.java
@@ -18,10 +18,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.spec.SecretKeySpec;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MultivaluedMap;
 
 import java.security.Key;
-import java.util.List;
 import java.util.Map;
 
 public class JwtAuthenticator
@@ -129,32 +127,10 @@ public class JwtAuthenticator
 
     private AuthenticatedUser createAuthenticatedUser(final int siteId, final ContainerRequestContext requestContext)
     {
-        // userInfo
-        final Config userInfo = cf.create();
-
-        // headers
-        final ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
-        final MultivaluedMap<String, String> headerMap = requestContext.getHeaders();
-        for (final String key : headerMap.keySet()) {
-            final List<String> values = headerMap.get(key);
-            headers.put(key, toHeaderString(values));
-        }
-
-        return AuthenticatedUser.of(siteId, userInfo, headers.build());
-    }
-
-    // ported from org.jboss.resteasy.specimpl.ResteasyHttpHeaders#getHeaderString
-    private String toHeaderString(final List<String> vals)
-    {
-        if (vals == null) return null;
-        StringBuilder builder = new StringBuilder();
-        boolean first = true;
-        for (String val : vals)
-        {
-            if (first) first = false;
-            else builder.append(",");
-            builder.append(val);
-        }
-        return builder.toString();
+        return AuthenticatedUser.builder()
+                .siteId(siteId)
+                .userInfo(cf.create())
+                .userContext(cf.create())
+                .build();
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/JwtAuthenticator.java
+++ b/digdag-server/src/main/java/io/digdag/server/JwtAuthenticator.java
@@ -118,17 +118,16 @@ public class JwtAuthenticator
             }
         }
 
-        return Result.builder()
-                .siteId(siteId)
-                .isAdmin(admin)
-                .authenticatedUser(createAuthenticatedUser(siteId, requestContext))
-                .build();
+        return Result.accept(
+                createAuthenticatedUser(siteId, admin, requestContext),
+                () -> ImmutableMap.of());
     }
 
-    private AuthenticatedUser createAuthenticatedUser(final int siteId, final ContainerRequestContext requestContext)
+    private AuthenticatedUser createAuthenticatedUser(final int siteId, final boolean admin, final ContainerRequestContext requestContext)
     {
         return AuthenticatedUser.builder()
                 .siteId(siteId)
+                .isAdmin(admin)
                 .userInfo(cf.create())
                 .userContext(cf.create())
                 .build();

--- a/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
+++ b/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
@@ -1,6 +1,6 @@
 package io.digdag.server.ac;
 
-import io.digdag.client.config.Config;
+import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ac.ProjectTarget;
@@ -11,200 +11,200 @@ public class DefaultAccessController
         implements AccessController
 {
     @Override
-    public void checkPutProject(ProjectTarget target, Config user)
+    public void checkPutProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkDeleteProject(ProjectTarget target, Config user)
+    public void checkDeleteProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetProject(ProjectTarget target, Config user)
+    public void checkGetProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkListProjectsOfSite(SiteTarget target, Config user)
+    public void checkListProjectsOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListProjectsFilterOfSite(SiteTarget target, Config user)
+    public ListFilter getListProjectsFilterOfSite(SiteTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkGetProjectArchive(ProjectTarget target, Config user)
+    public void checkGetProjectArchive(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkPutProjectSecret(ProjectTarget target, Config user)
+    public void checkPutProjectSecret(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkDeleteProjectSecret(ProjectTarget target, Config user)
+    public void checkDeleteProjectSecret(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetProjectSecrets(ProjectTarget target, Config user)
+    public void checkGetProjectSecrets(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetWorkflow(WorkflowTarget target, Config user)
+    public void checkGetWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkListWorkflowsOfSite(SiteTarget target, Config user)
+    public void checkListWorkflowsOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListWorkflowsFilterOfSite(SiteTarget target, Config user)
+    public ListFilter getListWorkflowsFilterOfSite(SiteTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkListWorkflowsOfProject(ProjectTarget target, Config user)
+    public void checkListWorkflowsOfProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListWorkflowsFilterOfProject(ProjectTarget target, Config user)
+    public ListFilter getListWorkflowsFilterOfProject(ProjectTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkRunWorkflow(WorkflowTarget target, Config user)
+    public void checkRunWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkPutLogFile(WorkflowTarget target, Config user)
+    public void checkPutLogFile(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetLogFiles(WorkflowTarget target, Config user)
+    public void checkGetLogFiles(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetSession(WorkflowTarget target, Config user)
+    public void checkGetSession(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkListSessionsOfSite(SiteTarget target, Config user)
+    public void checkListSessionsOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListSessionsFilterOfSite(SiteTarget target, Config user)
+    public ListFilter getListSessionsFilterOfSite(SiteTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkListSessionsOfProject(ProjectTarget target, Config user)
+    public void checkListSessionsOfProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListSessionsFilterOfProject(ProjectTarget target, Config user)
+    public ListFilter getListSessionsFilterOfProject(ProjectTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkListSessionsOfWorkflow(WorkflowTarget target, Config user)
+    public void checkListSessionsOfWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListSessionsFilterOfWorkflow(WorkflowTarget target, Config user)
+    public ListFilter getListSessionsFilterOfWorkflow(WorkflowTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkGetAttemptsFromSession(WorkflowTarget target, Config user)
+    public void checkGetAttemptsFromSession(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetAttempt(WorkflowTarget target, Config user)
+    public void checkGetAttempt(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetTasksFromAttempt(WorkflowTarget target, Config user)
+    public void checkGetTasksFromAttempt(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkKillAttempt(WorkflowTarget target, Config user)
+    public void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkGetSchedule(WorkflowTarget target, Config user)
+    public void checkGetSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkListSchedulesOfSite(SiteTarget target, Config user)
+    public void checkListSchedulesOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListSchedulesFilterOfSite(SiteTarget target, Config user)
+    public ListFilter getListSchedulesFilterOfSite(SiteTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkListSchedulesOfProject(ProjectTarget target, Config user)
+    public void checkListSchedulesOfProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public ListFilter getListSchedulesFilterOfProject(ProjectTarget target, Config user)
+    public ListFilter getListSchedulesFilterOfProject(ProjectTarget target, AuthenticatedUser user)
     {
         return () -> "true";
     }
 
     @Override
-    public void checkGetScheduleFromWorkflow(WorkflowTarget target, Config user)
+    public void checkGetScheduleFromWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkSkipSchedule(WorkflowTarget target, Config user)
+    public void checkSkipSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkBackfillSchedule(WorkflowTarget target, Config user)
+    public void checkBackfillSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkDisableSchedule(WorkflowTarget target, Config user)
+    public void checkDisableSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkEnableSchedule(WorkflowTarget target, Config user)
+    public void checkEnableSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -111,32 +111,32 @@ public class AttemptResource
                     // of workflow
 
                     final WorkflowTarget wfTarget = WorkflowTarget.of(getSiteId(), wfName, proj.getName());
-                    ac.checkListSessionsOfWorkflow(wfTarget, getUserInfo()); // AccessControl
+                    ac.checkListSessionsOfWorkflow(wfTarget, getAuthenticatedUser()); // AccessControl
                     attempts = ss.getAttemptsOfWorkflow(includeRetried, proj.getId(), wfName, validPageSize, Optional.fromNullable(lastId),
                             ac.getListSessionsFilterOfWorkflow(
                                     wfTarget,
-                                    getUserInfo()));
+                                    getAuthenticatedUser()));
                 }
                 else {
                     // of project
 
                     final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), projName);
-                    ac.checkListSessionsOfProject(projTarget, getUserInfo()); // AccessControl
+                    ac.checkListSessionsOfProject(projTarget, getAuthenticatedUser()); // AccessControl
                     attempts = ss.getAttemptsOfProject(includeRetried, proj.getId(), validPageSize, Optional.fromNullable(lastId),
                             ac.getListSessionsFilterOfProject(
                                     projTarget,
-                                    getUserInfo()));
+                                    getAuthenticatedUser()));
                 }
             }
             else {
                 // of site
 
                 final SiteTarget siteTarget = SiteTarget.of(getSiteId());
-                ac.checkListSessionsOfSite(siteTarget, getUserInfo()); // AccessControl
+                ac.checkListSessionsOfSite(siteTarget, getAuthenticatedUser()); // AccessControl
                 attempts = ss.getAttempts(includeRetried, validPageSize, Optional.fromNullable(lastId),
                         ac.getListSessionsFilterOfSite(
                                 siteTarget,
-                                getUserInfo()));
+                                getAuthenticatedUser()));
             }
 
             return RestModels.attemptCollection(rm.getProjectStore(getSiteId()), attempts);
@@ -156,7 +156,7 @@ public class AttemptResource
 
             ac.checkGetAttempt( // AccessControl
                     WorkflowTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.attempt(attempt, proj.getName());
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -175,7 +175,7 @@ public class AttemptResource
 
             ac.checkGetAttemptsFromSession( // AccessControl
                     WorkflowTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             List<StoredSessionAttemptWithSession> attempts = sm.getSessionStore(getSiteId())
                     .getOtherAttempts(id); // should never throw NotFound
@@ -197,7 +197,7 @@ public class AttemptResource
 
             ac.checkGetTasksFromAttempt( // AccessControl
                     WorkflowTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             List<ArchivedTask> tasks = sm.getSessionStore(getSiteId())
                     .getTasksOfAttempt(id);
@@ -218,7 +218,7 @@ public class AttemptResource
 
             ac.checkRunWorkflow( // AccessControl
                     WorkflowTarget.of(getSiteId(), def.getProject().getName(), def.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             Optional<Long> resumingAttemptId = request.getResume()
                     .transform(r -> RestModels.parseAttemptId(r.getAttemptId()));
@@ -336,7 +336,7 @@ public class AttemptResource
 
             ac.checkKillAttempt( // AccessControl
                     WorkflowTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             boolean updated = executor.killAttemptById(getSiteId(), id); // should never throw NotFound
             if (!updated) {

--- a/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
@@ -2,6 +2,7 @@ package io.digdag.server.rs;
 
 import com.google.common.base.Supplier;
 import io.digdag.client.config.Config;
+import io.digdag.spi.AuthenticatedUser;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
@@ -17,12 +18,17 @@ public abstract class AuthenticatedResource
     {
         // siteId is set by JwtAuthInterceptor
         // TODO validate before causing NPE. Improve guice-rs to call @PostConstruct
-        return (int) request.getAttribute("siteId");
+        return getAuthenticatedUser().getSiteId();
     }
 
     protected Config getUserInfo()
     {
-        return (Config) request.getAttribute("userInfo");
+        return getAuthenticatedUser().getUserInfo();
+    }
+
+    protected AuthenticatedUser getAuthenticatedUser()
+    {
+        return (AuthenticatedUser) request.getAttribute("authenticatedUser");
     }
 
     /**

--- a/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
@@ -79,7 +79,7 @@ public class LogResource
             final LogFilePrefix prefix = getPrefix(attemptId, // NotFound, AccessControl
                     (p, a) -> ac.checkPutLogFile(
                             WorkflowTarget.of(getSiteId(), p.getName(), a.getSession().getWorkflowName()),
-                            getUserInfo()));
+                            getAuthenticatedUser()));
 
             byte[] data = ByteStreams.toByteArray(body);
             String fileName = logServer.putFile(prefix, taskName, Instant.ofEpochSecond(unixFileTime), nodeId, data);
@@ -102,7 +102,7 @@ public class LogResource
             final LogFilePrefix prefix = getPrefix(attemptId, // NotFound, AccessControl
                     (p, a) -> ac.checkPutLogFile(
                             WorkflowTarget.of(getSiteId(), p.getName(), a.getSession().getWorkflowName()),
-                            getUserInfo()));
+                            getAuthenticatedUser()));
 
             Optional<DirectUploadHandle> handle = logServer.getDirectUploadHandle(prefix, taskName, Instant.ofEpochSecond(unixFileTime), nodeId);
 
@@ -130,7 +130,7 @@ public class LogResource
             final LogFilePrefix prefix = getPrefix(attemptId, // NotFound, AccessControl
                     (p, a) -> ac.checkGetLogFiles(
                             WorkflowTarget.of(getSiteId(), p.getName(), a.getSession().getWorkflowName()),
-                            getUserInfo()));
+                            getAuthenticatedUser()));
             List<LogFileHandle> handles = logServer.getFileHandles(prefix, Optional.fromNullable(taskName));
             return RestModels.logFileHandleCollection(handles);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -148,7 +148,7 @@ public class LogResource
             final LogFilePrefix prefix = getPrefix(attemptId, // NotFound, AccessControl
                     (p, a) -> ac.checkGetLogFiles(
                             WorkflowTarget.of(getSiteId(), p.getName(), a.getSession().getWorkflowName()),
-                            getUserInfo()));
+                            getAuthenticatedUser()));
             return logServer.getFile(prefix, fileName);
         }, ResourceNotFoundException.class, IOException.class, StorageFileNotFoundException.class, AccessControlException.class);
     }

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -205,7 +205,7 @@ public class ProjectResource
 
             ac.checkGetProject( // AccessControl
                     ProjectTarget.of(getSiteId(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.project(proj, rev);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -227,7 +227,7 @@ public class ProjectResource
 
                     ac.checkGetProject( // AccessControl
                             ProjectTarget.of(getSiteId(), proj.getName()),
-                            getUserInfo());
+                            getAuthenticatedUser());
 
                     collection = ImmutableList.of(RestModels.project(proj, rev));
                 }
@@ -242,13 +242,13 @@ public class ProjectResource
 
                 ac.checkListProjectsOfSite( // AccessControl
                         siteTarget,
-                        getUserInfo());
+                        getAuthenticatedUser());
 
                 // TODO fix n-m db access
                 collection = ps.getProjects(100, Optional.absent(),
                         ac.getListProjectsFilterOfSite(
                                 siteTarget,
-                                getUserInfo()))
+                                getAuthenticatedUser()))
                         .stream()
                         .map(proj -> {
                             try {
@@ -280,7 +280,7 @@ public class ProjectResource
 
             ac.checkGetProject( // AccessControl
                     ProjectTarget.of(getSiteId(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.project(proj, rev);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -298,7 +298,7 @@ public class ProjectResource
 
             ac.checkGetProject( // AccessControl
                     ProjectTarget.of(getSiteId(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.revisionCollection(proj, revs);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -326,7 +326,7 @@ public class ProjectResource
 
             ac.checkGetWorkflow( // AccessControl
                     WorkflowTarget.of(getSiteId(), proj.getName(), name),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.workflowDefinition(proj, rev, def);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -367,7 +367,7 @@ public class ProjectResource
 
                     ac.checkGetWorkflow( // AccessControl
                             WorkflowTarget.of(getSiteId(), def.getName(), proj.getName()),
-                            getUserInfo());
+                            getAuthenticatedUser());
 
                     collection = ImmutableList.of(def);
                 }
@@ -383,13 +383,13 @@ public class ProjectResource
 
                 ac.checkListWorkflowsOfProject( // AccessControl
                         projTarget,
-                        getUserInfo());
+                        getAuthenticatedUser());
 
                 // TODO should here support pagination?
                 collection = ps.getWorkflowDefinitions(rev.getId(), Integer.MAX_VALUE, Optional.absent(),
                         ac.getListWorkflowsFilterOfProject(
                                 projTarget,
-                                getUserInfo()));
+                                getAuthenticatedUser()));
             }
             return RestModels.workflowDefinitionCollection(proj, rev, collection);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -417,7 +417,7 @@ public class ProjectResource
                 try {
                     ac.checkGetScheduleFromWorkflow( // AccessControl
                             WorkflowTarget.of(getSiteId(), workflowName, proj.getName()),
-                            getUserInfo());
+                            getAuthenticatedUser());
 
                     sched = scheduleStore.getScheduleByProjectIdAndWorkflowName(projectId, workflowName);
                     scheds = ImmutableList.of(sched);
@@ -434,12 +434,12 @@ public class ProjectResource
                 final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName());
                 ac.checkListSchedulesOfProject( // AccessControl
                         projTarget,
-                        getUserInfo());
+                        getAuthenticatedUser());
 
                 scheds = scheduleStore.getSchedulesByProjectId(projectId, 100, Optional.fromNullable(lastId),
                         ac.getListSchedulesFilterOfProject(
                                 projTarget,
-                                getUserInfo()));
+                                getAuthenticatedUser()));
             }
 
             return RestModels.scheduleCollection(projectStore, scheds);
@@ -470,12 +470,12 @@ public class ProjectResource
                 final WorkflowTarget wfTarget = WorkflowTarget.of(getSiteId(), workflowName, proj.getName());
                 ac.checkListSessionsOfWorkflow( // AccessControl
                         wfTarget,
-                        getUserInfo());
+                        getAuthenticatedUser());
 
                 sessions = ss.getSessionsOfWorkflowByName(proj.getId(), workflowName, validPageSize, Optional.fromNullable(lastId),
                         ac.getListSessionsFilterOfWorkflow(
                                 wfTarget,
-                                getUserInfo()));
+                                getAuthenticatedUser()));
             }
             else {
                 // of project
@@ -483,12 +483,12 @@ public class ProjectResource
                 final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName());
                 ac.checkListSessionsOfProject( // AccessControl
                         projTarget,
-                        getUserInfo());
+                        getAuthenticatedUser());
 
                 sessions = ss.getSessionsOfProject(proj.getId(), validPageSize, Optional.fromNullable(lastId),
                         ac.getListSessionsFilterOfProject(
                                 projTarget,
-                                getUserInfo()));
+                                getAuthenticatedUser()));
             }
 
             return RestModels.sessionCollection(ps, sessions);
@@ -510,7 +510,7 @@ public class ProjectResource
 
             ac.checkGetProjectArchive( // AccessControl
                     ProjectTarget.of(getSiteId(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             if (!archiveOrNone.isPresent()) {
                 throw new ResourceNotFoundException("Archive is not stored");
@@ -570,7 +570,7 @@ public class ProjectResource
 
             ac.checkDeleteProject( // AccessControl
                     ProjectTarget.of(getSiteId(), project.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return ProjectControl.deleteProject(ps, projId, (control, proj) -> {
                 StoredRevision rev = ps.getLatestRevision(proj.getId()); // check NotFound first
@@ -589,7 +589,7 @@ public class ProjectResource
     {
         ac.checkPutProject( // AccessControl
                 ProjectTarget.of(getSiteId(), name),
-                getUserInfo());
+                getAuthenticatedUser());
 
         return tm.<RestProject, IOException, ResourceConflictException, ResourceNotFoundException, AccessControlException>begin(() -> {
             Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "project= is required");
@@ -776,7 +776,7 @@ public class ProjectResource
 
             ac.checkPutProjectSecret( // AccessControl
                     ProjectTarget.of(getSiteId(), project.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             SecretControlStore store = scsp.getSecretControlStore(getSiteId());
 
@@ -802,7 +802,7 @@ public class ProjectResource
 
             ac.checkDeleteProjectSecret( // AccessControl
                     ProjectTarget.of(getSiteId(), project.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             SecretControlStore store = scsp.getSecretControlStore(getSiteId());
 
@@ -825,7 +825,7 @@ public class ProjectResource
 
             ac.checkGetProjectSecrets( // AccessControl
                     ProjectTarget.of(getSiteId(), project.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             SecretControlStore store = scsp.getSecretControlStore(getSiteId());
             List<String> keys = store.listProjectSecrets(projectId, SecretScopes.PROJECT);

--- a/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
@@ -79,14 +79,14 @@ public class ScheduleResource
         final SiteTarget siteTarget = SiteTarget.of(getSiteId());
         ac.checkListSchedulesOfSite( // AccessControl
                 siteTarget,
-                getUserInfo());
+                getAuthenticatedUser());
 
         return tm.begin(() -> {
             List<StoredSchedule> scheds = sm.getScheduleStore(getSiteId())
                     .getSchedules(100, Optional.fromNullable(lastId),
                             ac.getListSchedulesFilterOfSite(
                                     siteTarget,
-                                    getUserInfo()));
+                                    getAuthenticatedUser()));
 
             return RestModels.scheduleCollection(rm.getProjectStore(getSiteId()), scheds);
         });
@@ -107,7 +107,7 @@ public class ScheduleResource
 
             ac.checkGetSchedule( // AccessControl
                     WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.schedule(sched, proj, timeZone);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -131,7 +131,7 @@ public class ScheduleResource
 
             ac.checkSkipSchedule( // AccessControl
                     WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             StoredSchedule updated;
             if (request.getNextTime().isPresent()) {
@@ -176,7 +176,7 @@ public class ScheduleResource
 
             ac.checkBackfillSchedule( // AccessControl
                     WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             List<StoredSessionAttemptWithSession> attempts =
                     exec.backfill(getSiteId(), id,  // should never throw NotFound
@@ -205,7 +205,7 @@ public class ScheduleResource
 
             ac.checkDisableSchedule( // AccessControl
                     WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             StoredSchedule updated = sm.getScheduleStore(getSiteId()).updateScheduleById(id, (store, storedSchedule) -> { // should never throw NotFound
                 ScheduleControl lockedSched = new ScheduleControl(store, storedSchedule);
@@ -232,7 +232,7 @@ public class ScheduleResource
 
             ac.checkEnableSchedule( // AccessControl
                     WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             StoredSchedule updated = sm.getScheduleStore(getSiteId()).updateScheduleById(id, (store, storedSchedule) -> { // should never throw NotFound
                 ScheduleControl lockedSched = new ScheduleControl(store, storedSchedule);

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -79,7 +79,7 @@ public class SessionResource
         final SiteTarget siteTarget = SiteTarget.of(getSiteId());
         ac.checkListSessionsOfSite( // AccessControl
                 siteTarget,
-                getUserInfo());
+                getAuthenticatedUser());
 
         return tm.begin(() -> {
             ProjectStore rs = rm.getProjectStore(getSiteId());
@@ -89,7 +89,7 @@ public class SessionResource
             List<StoredSessionWithLastAttempt> sessions = ss.getSessions(validPageSize, Optional.fromNullable(lastId),
                     ac.getListSessionsFilterOfSite(
                             siteTarget,
-                            getUserInfo()));
+                            getAuthenticatedUser()));
 
             return RestModels.sessionCollection(rs, sessions);
         });
@@ -108,7 +108,7 @@ public class SessionResource
 
             ac.checkGetSession( // AccessControl
                     WorkflowTarget.of(getSiteId(), session.getWorkflowName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.session(session, proj.getName());
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -133,7 +133,7 @@ public class SessionResource
 
             ac.checkGetAttemptsFromSession( // AccessControl
                     WorkflowTarget.of(getSiteId(), session.getWorkflowName(), project.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             List<StoredSessionAttempt> attempts = ss.getAttemptsOfSession(id, validPageSize, Optional.fromNullable(lastId));
 

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -88,7 +88,7 @@ public class WorkflowResource
 
             ac.checkGetWorkflow( // AccessControl
                     WorkflowTarget.of(getSiteId(), def.getName(), proj.getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.workflowDefinition(proj, rev, def);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -102,7 +102,7 @@ public class WorkflowResource
             throws ResourceNotFoundException, AccessControlException
     {
         final SiteTarget siteTarget = SiteTarget.of(getSiteId());
-        ac.checkListWorkflowsOfSite(siteTarget, getUserInfo());  // AccessControl
+        ac.checkListWorkflowsOfSite(siteTarget, getAuthenticatedUser());  // AccessControl
 
         return tm.<RestWorkflowDefinitionCollection, ResourceNotFoundException, AccessControlException>begin(() -> {
             List<StoredWorkflowDefinitionWithProject> defs =
@@ -110,7 +110,7 @@ public class WorkflowResource
                             .getLatestActiveWorkflowDefinitions(Optional.fromNullable(count).or(100), Optional.fromNullable(lastId), // check NotFound first
                                     ac.getListWorkflowsFilterOfSite(
                                             SiteTarget.of(getSiteId()),
-                                            getUserInfo()));
+                                            getAuthenticatedUser()));
 
             return RestModels.workflowDefinitionCollection(defs);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -128,7 +128,7 @@ public class WorkflowResource
 
             ac.checkGetWorkflow( // AccessControl
                     WorkflowTarget.of(getSiteId(), def.getName(), def.getProject().getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             return RestModels.workflowDefinition(def);
         }, ResourceNotFoundException.class, AccessControlException.class);
@@ -151,7 +151,7 @@ public class WorkflowResource
 
             ac.checkGetWorkflow( // AccessControl
                     WorkflowTarget.of(getSiteId(), def.getName(), def.getProject().getName()),
-                    getUserInfo());
+                    getAuthenticatedUser());
 
             ZoneId timeZone = def.getTimeZone();
 

--- a/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
@@ -1,0 +1,20 @@
+package io.digdag.spi;
+
+import io.digdag.client.config.Config;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface AuthenticatedUser
+{
+    int getSiteId();
+
+    Config getUserInfo();
+
+    static AuthenticatedUser of(int siteId, Config userInfo)
+    {
+        return ImmutableAuthenticatedUser.builder()
+                .siteId(siteId)
+                .userInfo(userInfo)
+                .build();
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
@@ -8,8 +8,11 @@ public interface AuthenticatedUser
 {
     int getSiteId();
 
+    boolean isAdmin();
+
     Config getUserInfo();
 
+    // this context will not be stored on database instead of userInfo, which is stored as part of wf revision.
     Config getUserContext();
 
     static ImmutableAuthenticatedUser.Builder builder()

--- a/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
@@ -3,6 +3,8 @@ package io.digdag.spi;
 import io.digdag.client.config.Config;
 import org.immutables.value.Value;
 
+import java.util.Map;
+
 @Value.Immutable
 public interface AuthenticatedUser
 {
@@ -10,11 +12,14 @@ public interface AuthenticatedUser
 
     Config getUserInfo();
 
-    static AuthenticatedUser of(int siteId, Config userInfo)
+    Map<String, String> getHeaders();
+
+    static AuthenticatedUser of(int siteId, Config userInfo, Map<String, String> headers)
     {
         return ImmutableAuthenticatedUser.builder()
                 .siteId(siteId)
                 .userInfo(userInfo)
+                .headers(headers)
                 .build();
     }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/AuthenticatedUser.java
@@ -3,8 +3,6 @@ package io.digdag.spi;
 import io.digdag.client.config.Config;
 import org.immutables.value.Value;
 
-import java.util.Map;
-
 @Value.Immutable
 public interface AuthenticatedUser
 {
@@ -12,14 +10,10 @@ public interface AuthenticatedUser
 
     Config getUserInfo();
 
-    Map<String, String> getHeaders();
+    Config getUserContext();
 
-    static AuthenticatedUser of(int siteId, Config userInfo, Map<String, String> headers)
+    static ImmutableAuthenticatedUser.Builder builder()
     {
-        return ImmutableAuthenticatedUser.builder()
-                .siteId(siteId)
-                .userInfo(userInfo)
-                .headers(headers)
-                .build();
+        return ImmutableAuthenticatedUser.builder();
     }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
@@ -1,6 +1,6 @@
 package io.digdag.spi.ac;
 
-import io.digdag.client.config.Config;
+import io.digdag.spi.AuthenticatedUser;
 
 public interface AccessController
 {
@@ -22,7 +22,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkPutProject(ProjectTarget target, Config user)
+    void checkPutProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -32,7 +32,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkDeleteProject(ProjectTarget target, Config user)
+    void checkDeleteProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -42,7 +42,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetProject(ProjectTarget target, Config user)
+    void checkGetProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     // listing
@@ -54,7 +54,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListProjectsOfSite(SiteTarget target, Config user)
+    void checkListProjectsOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -64,7 +64,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListProjectsFilterOfSite(SiteTarget target, Config user);
+    ListFilter getListProjectsFilterOfSite(SiteTarget target, AuthenticatedUser user);
 
     // resource actions
 
@@ -75,7 +75,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetProjectArchive(ProjectTarget target, Config user)
+    void checkGetProjectArchive(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -85,7 +85,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkPutProjectSecret(ProjectTarget target, Config user)
+    void checkPutProjectSecret(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -95,7 +95,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkDeleteProjectSecret(ProjectTarget target, Config user)
+    void checkDeleteProjectSecret(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -105,7 +105,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetProjectSecrets(ProjectTarget target, Config user)
+    void checkGetProjectSecrets(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     //
@@ -121,7 +121,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetWorkflow(WorkflowTarget target, Config user)
+    void checkGetWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     // listing
@@ -133,7 +133,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListWorkflowsOfSite(SiteTarget target, Config user)
+    void checkListWorkflowsOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -143,7 +143,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListWorkflowsFilterOfSite(SiteTarget target, Config user);
+    ListFilter getListWorkflowsFilterOfSite(SiteTarget target, AuthenticatedUser user);
 
     /**
      * Check if the user has permissions to list workflows within the project.
@@ -152,7 +152,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListWorkflowsOfProject(ProjectTarget target, Config user)
+    void checkListWorkflowsOfProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -162,7 +162,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListWorkflowsFilterOfProject(ProjectTarget target, Config user);
+    ListFilter getListWorkflowsFilterOfProject(ProjectTarget target, AuthenticatedUser user);
 
     // resource actions
 
@@ -173,7 +173,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkRunWorkflow(WorkflowTarget target, Config user)
+    void checkRunWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -183,7 +183,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkPutLogFile(WorkflowTarget target, Config user)
+    void checkPutLogFile(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -193,7 +193,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetLogFiles(WorkflowTarget target, Config user)
+    void checkGetLogFiles(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     //
@@ -209,7 +209,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetSession(WorkflowTarget target, Config user)
+    void checkGetSession(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     // listing
@@ -221,7 +221,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListSessionsOfSite(SiteTarget target, Config user)
+    void checkListSessionsOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -231,7 +231,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListSessionsFilterOfSite(SiteTarget target, Config user);
+    ListFilter getListSessionsFilterOfSite(SiteTarget target, AuthenticatedUser user);
 
     /**
      * Check if the user has permissions to list sessions.
@@ -240,7 +240,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListSessionsOfProject(ProjectTarget target, Config user)
+    void checkListSessionsOfProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -250,7 +250,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListSessionsFilterOfProject(ProjectTarget target, Config user);
+    ListFilter getListSessionsFilterOfProject(ProjectTarget target, AuthenticatedUser user);
 
     /**
      * Check if the user has permissions to list sessions within the workflow.
@@ -259,7 +259,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListSessionsOfWorkflow(WorkflowTarget target, Config user)
+    void checkListSessionsOfWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -269,7 +269,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListSessionsFilterOfWorkflow(WorkflowTarget target, Config user);
+    ListFilter getListSessionsFilterOfWorkflow(WorkflowTarget target, AuthenticatedUser user);
 
     // resource actions
 
@@ -280,7 +280,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetAttemptsFromSession(WorkflowTarget target, Config user)
+    void checkGetAttemptsFromSession(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -290,7 +290,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetAttempt(WorkflowTarget target, Config user)
+    void checkGetAttempt(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -300,7 +300,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetTasksFromAttempt(WorkflowTarget target, Config user)
+    void checkGetTasksFromAttempt(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -310,7 +310,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkKillAttempt(WorkflowTarget target, Config user)
+    void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     //
@@ -326,7 +326,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetSchedule(WorkflowTarget target, Config user)
+    void checkGetSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     // listing
@@ -338,7 +338,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListSchedulesOfSite(SiteTarget target, Config user)
+    void checkListSchedulesOfSite(SiteTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -348,7 +348,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListSchedulesFilterOfSite(SiteTarget target, Config user);
+    ListFilter getListSchedulesFilterOfSite(SiteTarget target, AuthenticatedUser user);
 
     /**
      * Check if the user has permissions to list schedules within the project.
@@ -357,7 +357,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkListSchedulesOfProject(ProjectTarget target, Config user)
+    void checkListSchedulesOfProject(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -367,7 +367,7 @@ public interface AccessController
      * @param user
      * @return
      */
-    ListFilter getListSchedulesFilterOfProject(ProjectTarget target, Config user);
+    ListFilter getListSchedulesFilterOfProject(ProjectTarget target, AuthenticatedUser user);
 
     // resource actions
 
@@ -378,7 +378,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetScheduleFromWorkflow(WorkflowTarget target, Config user)
+    void checkGetScheduleFromWorkflow(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -388,7 +388,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkSkipSchedule(WorkflowTarget target, Config user)
+    void checkSkipSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -398,7 +398,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkBackfillSchedule(WorkflowTarget target, Config user)
+    void checkBackfillSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -408,7 +408,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkDisableSchedule(WorkflowTarget target, Config user)
+    void checkDisableSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -418,6 +418,6 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkEnableSchedule(WorkflowTarget target, Config user)
+    void checkEnableSchedule(WorkflowTarget target, AuthenticatedUser user)
             throws AccessControlException;
 }


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/936

siteId and userInfo are used as the subjects of access control on https://github.com/treasure-data/digdag/pull/936 but, it seems that they are not good enough for access control. This PR introduces spi.AuthenticatedUser and we can set additional information for access control to the userContext.